### PR TITLE
Added choices in argparse param

### DIFF
--- a/brut3k1t
+++ b/brut3k1t
@@ -12,7 +12,9 @@ def main():
     
     parser = argparse.ArgumentParser(description='Bruteforce framework written in Python')
     required = parser.add_argument_group('required arguments')
-    required.add_argument('-s', '--service', dest='service', help="Provide a service being attacked. Several protocols and services are supported")
+    required.add_argument('-s', '--service', dest='service', help="Provide a service being attacked.\
+                          The Protocols and Services supported are SSH, FTP, SMTP, XMPP, TELNET, INSTAGRAM, FACEBOOK, TWITTER",\
+                          metavar='',choices=['ssh', 'ftp', 'smtp', 'xmpp', 'telnet', 'instagram', 'facebook', 'twitter'])
     required.add_argument('-u', '--username', dest='username', help='Provide a valid username for service/protocol being executed')
     required.add_argument('-w', '--wordlist', dest='password', help='Provide a wordlist or directory to a wordlist')
     parser.add_argument('-a', '--address', dest='address', help='Provide host address for specified service. Required for certain protocols')


### PR DESCRIPTION
With choices parameter,if anybody enters wrong services the script would respond as 
`[shivankarmadaan@Shivankar-Madaan ~/github/brut3k1t] master $ python brut3k1t -s http
usage: brut3k1t [-h] [-s] [-u USERNAME] [-w PASSWORD] [-a ADDRESS] [-p PORT]
                [-d DELAY]
brut3k1t: error: argument -s/--service: invalid choice: 'http' (choose from 'ssh', 'ftp', 'smtp', 'xmpp', 'telnet', 'instagram', 'facebook', 'twitter')`

Also made the help now look like

`  -s , --service        Provide a service being attacked. The Protocols and
                        Services supported are SSH, FTP, SMTP, XMPP, TELNET,
                        INSTAGRAM, FACEBOOK, TWITTER`


User can now read the supported services from the above